### PR TITLE
removing the concept of possible_deployment_environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Here is an example of the output:
 
 ```text
   Current Deployment Environment: :test
-  Possible Deployment Environments: [:test, :localhost, :staging, :production]
   Features:
   - new_algorithm, enabled in [:localhost, :staging]
   - new_ui, enabled in [:localhost]
@@ -92,7 +91,7 @@ The package can be installed by adding `simple_feature_flags` to your list of de
 ```elixir
 def deps do
   [
-    {:simple_feature_flags, "~> 0.1.0"}
+    {:simple_feature_flags, "~> 0.1"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ Here is an example of the output:
 ...
 config :simple_feature_flags, :flags, %{
   current_deployment_environment: :test,
-  possible_deployment_environments: [:test, :localhost, :staging, :production],
   features: %{
     new_algorithm: %{enabled_in: [:localhost, :staging]},
     new_ui: %{enabled_in: [:localhost]}

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,7 +2,6 @@ import Config
 
 config :simple_feature_flags, :flags, %{
   current_deployment_environment: :test,
-  possible_deployment_environments: [:test, :localhost, :staging, :production],
   features: %{
     test_feature_1: %{enabled_in: [:all]},
     test_feature_2: %{enabled_in: :all},

--- a/lib/simple_feature_flags.ex
+++ b/lib/simple_feature_flags.ex
@@ -13,7 +13,7 @@ defmodule SimpleFeatureFlags do
 
   """
   def enabled?(feature) do
-    possible_deployment_environments =
+    enabled_in_these_environments =
       Application.get_env(:simple_feature_flags, :flags).features
       |> Map.fetch!(feature)
       |> Map.fetch!(:enabled_in)
@@ -21,10 +21,10 @@ defmodule SimpleFeatureFlags do
     current_deployment_environment =
       Application.get_env(:simple_feature_flags, :flags).current_deployment_environment
 
-    :all == possible_deployment_environments or
-      [:all] == possible_deployment_environments or
-      :all in possible_deployment_environments or
-      current_deployment_environment in possible_deployment_environments
+    :all == enabled_in_these_environments or
+      [:all] == enabled_in_these_environments or
+      :all in enabled_in_these_environments or
+      current_deployment_environment in enabled_in_these_environments
   end
 
   @doc """
@@ -33,7 +33,7 @@ defmodule SimpleFeatureFlags do
   ## Examples
 
       iex> SimpleFeatureFlags.current_configuration_to_string()
-      "Current Deployment Environment: :test\\nPossible Deployment Environments: [:test, :localhost, :staging, :production]\\nFeatures:\\n - test_feature_1, enabled in [:all]\\n - test_feature_2, enabled in :all\\n - test_feature_3, enabled in [:test]\\n - test_feature_4, enabled in [:staging, :test, :production]\\n - test_feature_5, enabled in [:staging, :production]\\n - test_feature_6, enabled in []\\n"
+      "Current Deployment Environment: :test\\nFeatures:\\n - test_feature_1, enabled in [:all]\\n - test_feature_2, enabled in :all\\n - test_feature_3, enabled in [:test]\\n - test_feature_4, enabled in [:staging, :test, :production]\\n - test_feature_5, enabled in [:staging, :production]\\n - test_feature_6, enabled in []\\n"
 
   """
   def current_configuration_to_string() do
@@ -44,16 +44,13 @@ defmodule SimpleFeatureFlags do
   @doc false
   def configuration_to_string(%{
         current_deployment_environment: current_deployment_environment,
-        possible_deployment_environments: possible_deployment_environments,
         features: features
       })
       when is_atom(current_deployment_environment) and
              current_deployment_environment != nil and
-             is_list(possible_deployment_environments) and
              is_map(features) do
     """
     Current Deployment Environment: #{inspect(current_deployment_environment)}
-    Possible Deployment Environments: #{inspect(possible_deployment_environments)}
     Features:
     """ <>
       (for {feature_name, %{enabled_in: enabled_in}} <- features do

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule SimpleFeatureFlags.MixProject do
     [
       app: :simple_feature_flags,
       description: "Simple feature flags",
-      version: "0.1.1",
+      version: "0.1.2",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/simple_feature_flags_test.exs
+++ b/test/simple_feature_flags_test.exs
@@ -33,7 +33,6 @@ defmodule SimpleFeatureFlagsTest do
       assert SimpleFeatureFlags.current_configuration_to_string() ==
                """
                Current Deployment Environment: :test
-               Possible Deployment Environments: [:test, :localhost, :staging, :production]
                Features:
                 - test_feature_1, enabled in [:all]
                 - test_feature_2, enabled in :all
@@ -50,7 +49,6 @@ defmodule SimpleFeatureFlagsTest do
       assert SimpleFeatureFlags.configuration_to_string(configuration) ==
                """
                Current Deployment Environment: :test
-               Possible Deployment Environments: [:test, :localhost, :staging, :production]
                Features:
                 - test_feature_1, enabled in [:all]
                 - test_feature_2, enabled in :all


### PR DESCRIPTION
The concept of `possible_deployment_environments`, which was supposed to provide a bit of safety checking, appears to be more confusing than useful in practice, so removing it. 